### PR TITLE
fix: handle JSON sprites and image fallbacks

### DIFF
--- a/pokemon-backend/server.js
+++ b/pokemon-backend/server.js
@@ -21,18 +21,41 @@ const pool = new Pool({
 });
 
 // ====== Helpers de conversão (COM A CORREÇÃO) ======
+function safeParse(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value === 'string') {
+    try { return JSON.parse(value); } catch { return fallback; }
+  }
+  return value; // já é objeto/array
+}
+
 function mapRow(row) {
-  // Esta função agora converte as strings JSON do banco de dados de volta para objetos,
-  // corrigindo os bugs de exibição no aplicativo.
+  const types = safeParse(row.types, []);
+  const stats = safeParse(row.stats, {});
+  const abilities = safeParse(row.abilities, []);
+  const rawSprites = safeParse(row.sprites, {});
+
+  // Derivar arte oficial e animado com fallbacks robustos
+  const officialArtwork =
+    rawSprites.officialArtwork
+    || rawSprites?.other?.['official-artwork']?.front_default
+    || rawSprites.front_default
+    || null;
+
+  const animated =
+    rawSprites.animated
+    || rawSprites?.versions?.['generation-v']?.['black-white']?.animated?.front_default
+    || null;
+
   return {
     id: row.id,
     name: row.name,
-    types: JSON.parse(row.types || '[]'),
-    stats: JSON.parse(row.stats || '{}'),
+    types,
+    stats,
     height: row.height,
     weight: row.weight,
-    abilities: JSON.parse(row.abilities || '[]'),
-    sprites: JSON.parse(row.sprites || '{}'),
+    abilities,
+    sprites: { ...rawSprites, officialArtwork, animated },
   };
 }
 

--- a/primeiro-app/Page2.js
+++ b/primeiro-app/Page2.js
@@ -51,7 +51,11 @@ const StatBar = ({ label, value, theme }) => {
 
 // Card do Pokémon
 const PokemonCard = ({ item, theme, onLongPress, onPress }) => {
-  const imageUrl = item.sprites?.officialArtwork;
+  const imageUrl =
+    item.sprites?.officialArtwork
+    || item.sprites?.front_default
+    || item.sprites?.other?.['official-artwork']?.front_default
+    || null;
   return (
     <TouchableOpacity
       style={[styles.pokemonBox, { backgroundColor: theme.card }]}
@@ -97,20 +101,24 @@ export default function Page2({
     }
     const animated = selectedPokemon?.sprites?.animated;
     const official = selectedPokemon?.sprites?.officialArtwork;
+    const front = selectedPokemon?.sprites?.front_default;
 
-    const hasAnimated = typeof animated === "string" && animated.trim().length > 0;
-    const hasOfficial = typeof official === "string" && official.trim().length > 0;
-
-    setGifUri(hasAnimated ? animated : hasOfficial ? official : null);
+    const has = (s) => typeof s === "string" && s.trim().length > 0;
+    setGifUri(
+      has(animated) ? animated : has(official) ? official : has(front) ? front : null
+    );
   }, [selectedPokemon]);
 
   const handleGifError = () => {
-    // Se o GIF falhar, tenta a oficial; se já estiver na oficial ou não existir, usa placeholder
+    // Se a imagem atual falhar, tenta a próxima opção de fallback
     const official = selectedPokemon?.sprites?.officialArtwork;
-    const hasOfficial = typeof official === "string" && official.trim().length > 0;
+    const front = selectedPokemon?.sprites?.front_default;
+    const has = (s) => typeof s === "string" && s.trim().length > 0;
 
-    if (gifUri && hasOfficial && gifUri !== official) {
+    if (gifUri && has(official) && gifUri !== official) {
       setGifUri(official);
+    } else if (gifUri && has(front) && gifUri !== front) {
+      setGifUri(front);
     } else {
       setGifUri(null); // força placeholder
     }

--- a/primeiro-app/Page6.js
+++ b/primeiro-app/Page6.js
@@ -85,7 +85,11 @@ export default function Page6({ theme, onBack }) {
       speed: Number(speed) || 0,
     };
     const sprites = {};
-    if (spriteUrl.trim()) sprites.front_default = spriteUrl.trim();
+    if (spriteUrl.trim()) {
+      sprites.front_default = spriteUrl.trim();
+      // ao menos garantir officialArtwork com o mesmo link
+      if (!sprites.officialArtwork) sprites.officialArtwork = sprites.front_default;
+    }
 
     return {
       name: name.trim(),

--- a/primeiro-app/apiUrl.js
+++ b/primeiro-app/apiUrl.js
@@ -1,14 +1,7 @@
-// primeiro-app/apiUrl.js (VERSÃO FINAL PARA PRODUÇÃO)
 import { Platform } from 'react-native';
 
-// URL pública do seu servidor no Render, que já está online.
 const PUBLIC_API_URL = 'https://pokedex-api-gito.onrender.com';
+const LOCAL_API_URL =
+  Platform.OS === 'android' ? 'http://10.0.2.2:3000' : 'http://localhost:3000';
 
-/**
- * Retorna a URL base da API.
- * Para o aplicativo final (APK), esta função sempre retornará a URL pública
- * para garantir que ele funcione em qualquer rede (Wi-Fi, 4G, 5G).
- */
-export const getApiBaseUrl = () => {
-  return PUBLIC_API_URL;
-};
+export const getApiBaseUrl = () => (__DEV__ ? LOCAL_API_URL : PUBLIC_API_URL);


### PR DESCRIPTION
## Summary
- safely parse JSON columns and derive sprite fallbacks
- show Pokémon images with multiple fallbacks in list and popup
- populate officialArtwork in CRUD forms
- use local API base URL during development

## Testing
- `npm test` (pokemon-backend) *(fails: Error: no test specified)*
- `npm test` (primeiro-app) *(fails: Missing script: "test")*


------
